### PR TITLE
conda-package-handling 2.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-package-handling" %}
-{% set version = "2.0.2" %}
+{% set version = "2.1.0" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://github.com/conda/conda-package-handling/archive/{{ version }}.tar.gz
-  sha256: ec0a2c51f442d98b935ee2288beb1ec6c7e25020b5961f8d09f35738b276b532
+  sha256: dcaa757fca94857420acd21b27d1ff6939e34522d196c3bafdd6dfed90559da5
 
 build:
   number: 0
   skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - cph = conda_package_handling.cli:main
 
@@ -49,8 +49,6 @@ about:
   home: https://github.com/conda/conda-package-handling
   dev_url: https://github.com/conda/conda-package-handling
   doc_url: https://conda.github.io/conda-package-handling/
-  doc_source_url: https://github.com/conda/conda-package-handling/tree/{{ version }}/docs
-  license_url: https://github.com/conda/conda-package-handling/blob/{{ version }}/LICENSE
   license: BSD-3-Clause
   license_family: BSD
   license_file:


### PR DESCRIPTION
Changelog: https://github.com/conda/conda-package-handling/releases
Requirements: https://github.com/conda/conda-package-handling/blob/2.1.0/setup.py

Actions:
1. Add  `--no-build-isolation` to `script`
2. Remove overspecified `doc_source_url` & `license_url`