### PR TITLE
conda-package-handling 2.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,9 @@ build:
     - cph = conda_package_handling.cli:main
 
 requirements:
+  # Use this build section with python to avoid an Unexpected conda error on CI
+  build:
+    - python
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-package-handling" %}
-{% set version = "2.1.0" %}
+{% set version = "2.2.0" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/conda/conda-package-handling/archive/{{ version }}.tar.gz
-  sha256: dcaa757fca94857420acd21b27d1ff6939e34522d196c3bafdd6dfed90559da5
+  sha256: dae0c697cf8757d997d0d7f4fbe48a5516cb17f16b3715dadb6008ade8ef850e
 
 build:
   number: 0
@@ -17,8 +17,6 @@ build:
     - cph = conda_package_handling.cli:main
 
 requirements:
-  build:
-    - python
   host:
     - python
     - pip
@@ -26,7 +24,7 @@ requirements:
     - wheel
   run:
     - python
-    - conda-package-streaming >=0.7.0
+    - conda-package-streaming >=0.9.0
 
 test:
   source_files:
@@ -51,8 +49,7 @@ about:
   doc_url: https://conda.github.io/conda-package-handling/
   license: BSD-3-Clause
   license_family: BSD
-  license_file:
-    - LICENSE
+  license_file: LICENSE
   summary: Create and extract conda packages of various formats
   description: |
     cph is an abstraction of conda package handling and a tool for extracting, creating, and converting between formats.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - wheel
   run:
     - python
+    - zstandard >=0.15
     - conda-package-streaming >=0.9.0
 
 test:
@@ -53,9 +54,11 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: Create and extract conda packages of various formats
+  summary: Create and extract conda packages of various formats.
   description: |
-    cph is an abstraction of conda package handling and a tool for extracting, creating, and converting between formats.
+    `conda` and `conda-build` use `conda_package_handling.api` to create and extract
+    conda packages. This package also provides the `cph` command line tool to
+    extract, create, and convert between formats.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/conda/conda-package-handling/blob/2.2.0/CHANGELOG.md
Requirements: https://github.com/conda/conda-package-handling/blob/2.2.0/setup.py

Actions:
1. Add a comment about the necessity of the `requirements/build` section
2. Update pinning in `run`: `conda-package-streaming >=0.9.0`
3. Fix `license_file` as a string and not an array