### PR TITLE
Building missing 3.12 packages

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+# to build 3.8 to 3.12 on prefect
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: dae0c697cf8757d997d0d7f4fbe48a5516cb17f16b3715dadb6008ade8ef850e
 
 build:
-  number: 0
+  number: 0 # trigger
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:


### PR DESCRIPTION
Changes:
- triggering a build for 3.12.
- not increasing the build number, skip-existing will take care of avoiding duplication.