### PR TITLE
conda-package-handling 2.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "conda-package-handling" %}
-{% set version = "2.4.0" %}
+{% set version = "2.5.0" %}
 
 package:
   name: {{ name }}
@@ -7,28 +7,25 @@ package:
 
 source:
   url: https://github.com/conda/conda-package-handling/archive/{{ version }}.tar.gz
-  sha256: a68d23d795704f1b687559b89c98e73d0dbebcab077592c60bffc1dc408b72e9
+  sha256: fb471058fc5cc3a1ab5c802492d080d4d6a3eb221ce3e9852380ca2d021f1b95
 
 build:
-  number: 1
-  skip: true  # [py<38]
+  number: 0
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - cph = conda_package_handling.cli:main
 
 requirements:
-  # Use this build section with python to avoid an Unexpected conda error on CI
-  build:
-    - python
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - flit-core >=3.2
   run:
     - python
+    - conda-package-streaming >=0.12.0
+    - requests
     - zstandard >=0.15
-    - conda-package-streaming >=0.9.0
 
 test:
   source_files:


### PR DESCRIPTION
## conda-package-handling 2.5.0

**Destination channel:** defaults

### Links
- [PKG-15337](https://anaconda.atlassian.net/browse/PKG-15337)
- [GitHub Release](https://github.com/conda/conda-package-handling/releases/tag/2.5.0)

### Explanation of changes:
- Updated conda-package-handling from 2.4.0 to 2.5.0
- Added `requests` to runtime dependencies (was missing upstream)
- Bumped `conda-package-streaming` pin from >=0.9.0 to >=0.12.0
- Switched build backend from setuptools to flit-core (matches upstream pyproject.toml)
- Removed legacy `build: python` workaround (no longer needed)
- Minimum Python version bumped from 3.8 to 3.10
- Route all `info/` paths into the `info-*` inner tarball when creating `.conda` packages (CEP 35)
- Python 3.14 support added

[PKG-15337]: https://anaconda.atlassian.net/browse/PKG-15337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ